### PR TITLE
Add links to problems in results and problem results sidebar

### DIFF
--- a/ext/js/background.js
+++ b/ext/js/background.js
@@ -288,7 +288,8 @@
     }
 
     async function getProblemList(contestID) {
-        return contestProblemList[contestID];
+        // TODO: Fetch problem list
+        return contestProblemList[contestID] ?? {};
     }
 
     retrieveLastContestID();

--- a/ext/js/background.js
+++ b/ext/js/background.js
@@ -288,7 +288,15 @@
     }
 
     async function getProblemList(contestID) {
-        // TODO: Fetch problem list
+        if (!contestProblemList[contestID]) {
+            try {
+                const response = await fetch(`${SATORI_URL_HTTPS}contest/${contestID}/problems`);
+                if (!response.ok) throw new Error(`HTTP Status ${response.status}`);
+                contestProblemList[contestID] = parseProblemList($.parseHTML(await response.text()));
+            } catch (error) {
+                console.error(error);
+            }
+        }
         return contestProblemList[contestID] ?? {};
     }
 

--- a/ext/js/background.js
+++ b/ext/js/background.js
@@ -22,6 +22,8 @@
      */
     let contestResultsRedirects = new Set();
 
+    const contestProblemList = {};
+
     function displayStatusNotification(submitID, problemCode, status) {
         browser.notifications.create({
             type: 'basic',
@@ -282,15 +284,11 @@
     }
 
     function saveContestProblemList(contestID, problems) {
-        storage.set({
-            [`contest-problems/${contestID}`]: problems
-        });
-        console.log(storage.get());
+        contestProblemList[contestID] = problems;
     }
 
     async function getProblemList(contestID) {
-        const key = `contest-problems/${contestID}`;
-        return (await storage.get(key))[key] ?? {};
+        return contestProblemList[contestID];
     }
 
     retrieveLastContestID();

--- a/ext/js/background.js
+++ b/ext/js/background.js
@@ -281,6 +281,18 @@
         });
     }
 
+    function saveContestProblemList(contestID, problems) {
+        storage.set({
+            [`contest-problems/${contestID}`]: problems
+        });
+        console.log(storage.get());
+    }
+
+    async function getProblemList(contestID) {
+        const key = `contest-problems/${contestID}`;
+        return (await storage.get(key))[key] ?? {};
+    }
+
     retrieveLastContestID();
     setUpLastContestRedirect();
     setUpSubmitRedirect();
@@ -307,6 +319,10 @@
             });
         } else if (request.action === 'injectHighlightJsCss') {
             injectHighlightJsCss(sender.tab);
+        } else if (request.action === 'saveContestProblemList') {
+            saveContestProblemList(request.contestID, request.problems);
+        } else if (request.action === 'getContestProblemList') {
+            return getProblemList(request.contestID);
         }
         return new Promise(resolve => resolve(null));
     });

--- a/ext/js/common.js
+++ b/ext/js/common.js
@@ -13,19 +13,24 @@ if (typeof module !== 'undefined') {
     };
 }
 
-function updateProblemList(column) {
+function updateProblemList(isResultList) {
+    const column = isResultList ? 2 : 3;
     browser.runtime.sendMessage({
         action: 'getContestProblemList',
         contestID: getContestID(document.location.href),
     }).then((problems) => {
-        console.log(getContestID(document.location.href), problems);
         for (const el of $(`table.results > tbody > tr:not(:first-of-type) > td:nth-child(${column})`)) {
             const code = $(el).text();
             const problem = problems[code];
             if (!problem) continue;
+            const statementHref = problem.href || problem.pdfHref;
+            if (!statementHref) {
+                $(el).text(`${code} - ${problem.title}`);
+                return;
+            }
             const link = $('<a class="stdlink"></a>');
-            link.attr('href', problem.href);
-            link.text(`${code} - ${problem.title}`)
+            link.attr('href', statementHref);
+            link.text(`${code} - ${problem.title}`);
             $(el).empty().append(link);
         }
     });

--- a/ext/js/common.js
+++ b/ext/js/common.js
@@ -27,7 +27,23 @@ if (typeof module !== 'undefined') {
     };
 }
 
-async function updateProblemList(isResultList) {
+function parseProblemList(jqueryHandles) {
+    return Object.fromEntries(jqueryHandles.flatMap(
+        (el) => [...$(el).find('#content table.results tr:not(:first-of-type)')].map(
+            (tr) => [
+                $(tr).find('td:nth-child(1)').text(),
+                {
+                    title: $(tr).find('td:nth-child(2)').text(),
+                    href: $(tr).find('td:nth-child(2) a').attr('href'),
+                    pdfHref: $(tr).find('td:nth-child(3) a').attr('href'),
+                    submitHref: $(tr).find('td:nth-child(5) a').attr('href'),
+                }
+            ]
+        ))
+    );
+}
+
+async function insertProblemLinks(isResultList) {
     const column = isResultList ? 2 : 3;
     const problems = await browser.runtime.sendMessage({
         action: 'getContestProblemList',

--- a/ext/js/common.js
+++ b/ext/js/common.js
@@ -27,25 +27,28 @@ if (typeof module !== 'undefined') {
     };
 }
 
-function updateProblemList(isResultList) {
+async function updateProblemList(isResultList) {
     const column = isResultList ? 2 : 3;
-    browser.runtime.sendMessage({
+    const problems = await browser.runtime.sendMessage({
         action: 'getContestProblemList',
         contestID: getContestID(document.location.href),
-    }).then((problems) => {
-        for (const el of $(`table.results > tbody > tr:not(:first-of-type) > td:nth-child(${column})`)) {
-            const code = $(el).text();
-            const problem = problems[code];
-            if (!problem) continue;
-            const statementHref = problem.href || problem.pdfHref;
-            if (!statementHref) {
-                $(el).text(`${code} - ${problem.title}`);
-                return;
-            }
-            const link = $('<a class="stdlink"></a>');
-            link.attr('href', statementHref);
-            link.text(`${code} - ${problem.title}`);
-            $(el).empty().append(link);
-        }
     });
+
+    let submitHref;
+    for (const el of $(`table.results > tbody > tr:not(:first-of-type) > td:nth-child(${column})`)) {
+        const code = $(el).text();
+        const problem = problems[code];
+        if (!problem) continue;
+        if (problem.submitHref) submitHref = problem.submitHref;
+        const statementHref = problem.href || problem.pdfHref;
+        if (!statementHref) {
+            $(el).text(`${code} - ${problem.title}`);
+            continue;
+        }
+        const link = $('<a class="stdlink"></a>');
+        link.attr('href', statementHref);
+        link.text(`${code} - ${problem.title}`);
+        $(el).empty().append(link);
+    }
+    return submitHref;
 }

--- a/ext/js/common.js
+++ b/ext/js/common.js
@@ -4,12 +4,26 @@
  * @returns {string} contest ID
  */
 function getContestID(url) {
-    return PROBLEM_URL_REGEX.exec(url)[1];
+    return CONTEST_URL_REGEX.exec(url)[1];
+}
+
+/**
+ * Parse given problem URL and return the contest and problem ID.
+ * @param {string} url URL to parse
+ * @returns {object} contest and problem ID
+ */
+function getContestAndProblemID(url) {
+    const match = PROBLEM_URL_REGEX.exec(url);
+    return {
+        contestID: match[1],
+        problemID: match[2],
+    }
 }
 
 if (typeof module !== 'undefined') {
     module.exports = {
-        getContestID
+        getContestID,
+        getContestAndProblemID,
     };
 }
 

--- a/ext/js/common.js
+++ b/ext/js/common.js
@@ -12,3 +12,21 @@ if (typeof module !== 'undefined') {
         getContestID
     };
 }
+
+function updateProblemList(column) {
+    browser.runtime.sendMessage({
+        action: 'getContestProblemList',
+        contestID: getContestID(document.location.href),
+    }).then((problems) => {
+        console.log(getContestID(document.location.href), problems);
+        for (const el of $(`table.results > tbody > tr:not(:first-of-type) > td:nth-child(${column})`)) {
+            const code = $(el).text();
+            const problem = problems[code];
+            if (!problem) continue;
+            const link = $('<a class="stdlink"></a>');
+            link.attr('href', problem.href);
+            link.text(`${code} - ${problem.title}`)
+            $(el).empty().append(link);
+        }
+    });
+}

--- a/ext/js/config.js
+++ b/ext/js/config.js
@@ -1,8 +1,10 @@
 const SATORI_URL = 'satori.tcs.uj.edu.pl/';
 const SATORI_URL_HTTP = 'http://' + SATORI_URL;
 const SATORI_URL_HTTPS = 'https://' + SATORI_URL;
-const PROBLEM_URL_REGEX =
+const CONTEST_URL_REGEX =
     /https:\/\/satori\.tcs\.uj\.edu\.pl\/contest\/(\d+)\//;
+const PROBLEM_URL_REGEX =
+    /https:\/\/satori\.tcs\.uj\.edu\.pl\/contest\/(\d+)\/problems\/(\d+)/;
 
 const CHOSEN_LOGO_PRIMARY_KEY = 'chosenLogo_primary';
 const CHOSEN_LOGO_SECONDARY_KEY = 'chosenLogo_secondary';
@@ -42,6 +44,7 @@ if (typeof module !== 'undefined') {
         SATORI_URL,
         SATORI_URL_HTTP,
         SATORI_URL_HTTPS,
+        CONTEST_URL_REGEX,
         PROBLEM_URL_REGEX,
 
         CHOSEN_LOGO_PRIMARY_KEY,

--- a/ext/js/problem.js
+++ b/ext/js/problem.js
@@ -1,0 +1,9 @@
+(function () {
+    'use strict';
+
+    const { contestID, problemID } = getContestAndProblemID(document.location.href);
+    console.log(contestID, problemID);
+    $('<a class="button">Results</a>')
+        .attr('href', `${SATORI_URL_HTTPS}contest/${contestID}/results?results_filter_problem=${problemID}`)
+        .appendTo('#content > .buttton_bar')
+})();

--- a/ext/js/problem.js
+++ b/ext/js/problem.js
@@ -2,7 +2,6 @@
     'use strict';
 
     const { contestID, problemID } = getContestAndProblemID(document.location.href);
-    console.log(contestID, problemID);
     $('<a class="button">Results</a>')
         .attr('href', `${SATORI_URL_HTTPS}contest/${contestID}/results?results_filter_problem=${problemID}`)
         .appendTo('#content > .buttton_bar')

--- a/ext/js/problem.js
+++ b/ext/js/problem.js
@@ -2,7 +2,48 @@
     'use strict';
 
     const { contestID, problemID } = getContestAndProblemID(document.location.href);
+    const resultsUrl = `${SATORI_URL_HTTPS}contest/${contestID}/results?results_filter_problem=${problemID}`;
     $('<a class="button">Results</a>')
-        .attr('href', `${SATORI_URL_HTTPS}contest/${contestID}/results?results_filter_problem=${problemID}`)
+        .attr('href', resultsUrl)
         .appendTo('#content > .buttton_bar')
+
+    function parseResultsPage(html) {
+        for (const x of $.parseHTML(html)) {
+            const content = $(x).find('#content');
+            if (content.length > 0) return content;
+        }
+    }
+
+    async function loadResults() {
+        const response = await fetch(`${resultsUrl}&results_limit=20`);
+        if (!response.ok) throw Error(`Results request failed with HTTP status code ${response.status}`);
+        const content = parseResultsPage(await response.text());
+        const table = content.find('> table.results');
+        if (!table) return;
+        table.find('td:nth-child(2), th:nth-child(2)').remove();
+
+        if (table.find('tr:not(:first-child)').length === 0) {
+            $('<tr><td colspan="3" class="centered">No submissions yet</td></tr>')
+                .appendTo(table);
+        }
+
+        // Page selector has more than one page - show link to see all submissions
+        if (content.find('> .wheel > a.wheelitem').length > 0) {
+            const row = $('<tr><td colspan="3" class="centered"><a class="stdlink">See more submissions</a></td></tr>');
+            row.find('a').attr('href', resultsUrl);
+            table.append(row);
+        }
+
+        $(
+            '<div id="results-sidebar">' +
+            '   <h3>Recent submission results</h3>' +
+            '</div>'
+        )
+            .append(table)
+            .insertAfter('#content');
+    }
+
+    loadResults().catch((error) => {
+        console.error('Failed to load recent submissions', error);
+    });
 })();

--- a/ext/js/problems.js
+++ b/ext/js/problems.js
@@ -261,24 +261,12 @@
     const contestID = getContestID(document.location.href);
     const resultsURL = `${SATORI_URL_HTTPS}contest/${contestID}/results`;
 
-    function saveProblemList() {
-        const problems = Object.fromEntries($.find('#content table.results tr:not(:first-of-type)').map((el) => [
-            $(el).find('td:nth-child(1)').text(),
-            {
-                title:      $(el).find('td:nth-child(2)').text(),
-                href:       $(el).find('td:nth-child(2) a').attr('href'),
-                pdfHref:    $(el).find('td:nth-child(3) a').attr('href'),
-                submitHref: $(el).find('td:nth-child(5) a').attr('href'),
-            }
-        ]));
-        browser.runtime.sendMessage({
-            action: 'saveContestProblemList',
-            contestID,
-            problems,
-        });
-    }
+    browser.runtime.sendMessage({
+        action: 'saveContestProblemList',
+        contestID,
+        problems: parseProblemList([$]),
+    });
 
-    saveProblemList();
     hideProblemGroups();
     connectGroupHideLinks();
     const table = $('table.results');

--- a/ext/js/problems.js
+++ b/ext/js/problems.js
@@ -265,8 +265,10 @@
         const problems = Object.fromEntries($.find('#content table.results tr:not(:first-of-type)').map((el) => [
             $(el).find('td:nth-child(1)').text(),
             {
-                href: $(el).find('td:nth-child(2) a').attr('href'),
-                title: $(el).find('td:nth-child(2)').text(),
+                title:      $(el).find('td:nth-child(2)').text(),
+                href:       $(el).find('td:nth-child(2) a').attr('href'),
+                pdfHref:    $(el).find('td:nth-child(3) a').attr('href'),
+                submitHref: $(el).find('td:nth-child(5) a').attr('href'),
             }
         ]));
         browser.runtime.sendMessage({

--- a/ext/js/problems.js
+++ b/ext/js/problems.js
@@ -257,16 +257,30 @@
             });
     }
 
-    hideProblemGroups();
-    connectGroupHideLinks();
-    const table = $('table.results');
-    table.each((index, table) => processProblemGroup($(table)));
-
-
     // "Results" constants
     const contestID = getContestID(document.location.href);
     const resultsURL = `${SATORI_URL_HTTPS}contest/${contestID}/results`;
 
+    function saveProblemList() {
+        const problems = Object.fromEntries($.find('#content table.results tr:not(:first-of-type)').map((el) => [
+            $(el).find('td:nth-child(1)').text(),
+            {
+                href: $(el).find('td:nth-child(2) a').attr('href'),
+                title: $(el).find('td:nth-child(2)').text(),
+            }
+        ]));
+        browser.runtime.sendMessage({
+            action: 'saveContestProblemList',
+            contestID,
+            problems,
+        });
+    }
+
+    saveProblemList();
+    hideProblemGroups();
+    connectGroupHideLinks();
+    const table = $('table.results');
+    table.each((index, table) => processProblemGroup($(table)));
 
     // "Results" button
     const submitUrlRegex = /submit\?select=(\d+)/;

--- a/ext/js/results-list.js
+++ b/ext/js/results-list.js
@@ -10,5 +10,5 @@
         }
     });
 
-    updateProblemList(2);
+    updateProblemList(true);
 })();

--- a/ext/js/results-list.js
+++ b/ext/js/results-list.js
@@ -10,5 +10,16 @@
         }
     });
 
+    const contestID = getContestID(document.location.href);
+
+    function addCompareSubmitsButton() {
+        const problemID = new URLSearchParams(document.location.search).get('results_filter_problem');
+        if (!problemID || !/^\d+$/.test(problemID)) return;
+        $(`<a class="button">Submit another</a>`)
+            .attr('href', `${SATORI_URL_HTTPS}contest/${contestID}/submit?select=${problemID}`)
+            .appendTo('#content .button_bar')
+    }
+
+    addCompareSubmitsButton();
     insertProblemLinks(true);
 })();

--- a/ext/js/results-list.js
+++ b/ext/js/results-list.js
@@ -9,4 +9,6 @@
                 'tr:nth-child(2) > td:first > a').attr('href');
         }
     });
+
+    updateProblemList(2);
 })();

--- a/ext/js/results-list.js
+++ b/ext/js/results-list.js
@@ -10,5 +10,5 @@
         }
     });
 
-    updateProblemList(true);
+    insertProblemLinks(true);
 })();

--- a/ext/js/results.js
+++ b/ext/js/results.js
@@ -91,13 +91,13 @@
     insertProblemLinks(false).then((submitUrl) => {
         if (!submitUrl) return;
         const submitID = submitUrlRegex.exec(submitUrl)[1];
-        const submitButton = $('<a class="button">Submit another</a>')
-            .attr('href', submitUrl);
         const resultsButton = $('<a class="button">All submissions</a>')
             .attr('href', `${SATORI_URL_HTTPS}contest/${contestID}/results?results_filter_problem=${submitID}`);
+        const submitButton = $('<a class="button">Submit another</a>')
+            .attr('href', submitUrl);
         $('<div class="button_bar"></div>')
-            .append(submitButton)
             .append(resultsButton)
+            .append(submitButton)
             .insertAfter('#content .results')
     });
 })();

--- a/ext/js/results.js
+++ b/ext/js/results.js
@@ -85,4 +85,5 @@
     }
 
     initializeSyntaxHighlighter();
+    updateProblemList(3);
 })();

--- a/ext/js/results.js
+++ b/ext/js/results.js
@@ -17,6 +17,7 @@
     let problemStatus = tr.find('td:last').text();
 
     let url = document.location.href;
+    const contestID = getContestID(url);
 
     /**
      * Parse given HTML and return problem status code if it's found.
@@ -84,6 +85,19 @@
         });
     }
 
+    const submitUrlRegex = /submit\?select=(\d+)/;
+
     initializeSyntaxHighlighter();
-    updateProblemList(false);
+    updateProblemList(false).then((submitUrl) => {
+        if (!submitUrl) return;
+        const submitID = submitUrlRegex.exec(submitUrl)[1];
+        const submitButton = $('<a class="button">Submit another</a>')
+            .attr('href', submitUrl);
+        const resultsButton = $('<a class="button">All submissions</a>')
+            .attr('href', `${SATORI_URL_HTTPS}contest/${contestID}/results?results_filter_problem=${submitID}`);
+        $('<div class="button_bar"></div>')
+            .append(submitButton)
+            .append(resultsButton)
+            .insertAfter('#content .results')
+    });
 })();

--- a/ext/js/results.js
+++ b/ext/js/results.js
@@ -85,5 +85,5 @@
     }
 
     initializeSyntaxHighlighter();
-    updateProblemList(3);
+    updateProblemList(false);
 })();

--- a/ext/js/results.js
+++ b/ext/js/results.js
@@ -88,7 +88,7 @@
     const submitUrlRegex = /submit\?select=(\d+)/;
 
     initializeSyntaxHighlighter();
-    updateProblemList(false).then((submitUrl) => {
+    insertProblemLinks(false).then((submitUrl) => {
         if (!submitUrl) return;
         const submitID = submitUrlRegex.exec(submitUrl)[1];
         const submitButton = $('<a class="button">Submit another</a>')

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -104,6 +104,19 @@
       "css": ["css/problems.css"]
     },
     {
+      "matches": ["*://satori.tcs.uj.edu.pl/contest/*/problems/*"],
+      "js": [
+        "vendor/browser-polyfill.js",
+        "vendor/bower/jquery.min.js",
+        "js/common.js",
+        "js/problem.js"
+      ],
+      "run_at": "document_end",
+      "css": [
+        "css/problem.css"
+      ]
+    },
+    {
       "matches": [
         "*://satori.tcs.uj.edu.pl/contest/*/results",
         "*://satori.tcs.uj.edu.pl/contest/*/results?*"

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -104,10 +104,14 @@
       "css": ["css/problems.css"]
     },
     {
-      "matches": ["*://satori.tcs.uj.edu.pl/contest/*/results"],
+      "matches": [
+        "*://satori.tcs.uj.edu.pl/contest/*/results",
+        "*://satori.tcs.uj.edu.pl/contest/*/results?*"
+      ],
       "js": [
         "vendor/browser-polyfill.js",
         "vendor/bower/jquery.min.js",
+        "js/common.js",
         "js/results-list.js"
       ],
       "run_at": "document_end"
@@ -119,6 +123,7 @@
         "vendor/bower/jquery.min.js",
         "vendor/bower/highlight.pack.min.js",
         "vendor/bower/highlightjs-line-numbers.min.js",
+        "js/common.js",
         "js/results.js"
       ],
       "run_at": "document_end",

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -43,6 +43,7 @@
   "background": {
     "scripts": [
       "vendor/browser-polyfill.js",
+      "vendor/bower/jquery.min.js",
       "js/config.js",
       "js/common.js",
       "js/background.js"

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -93,7 +93,10 @@
       ]
     },
     {
-      "matches": ["*://satori.tcs.uj.edu.pl/contest/*/problems*"],
+      "matches": [
+        "*://satori.tcs.uj.edu.pl/contest/*/problems",
+        "*://satori.tcs.uj.edu.pl/contest/*/problems?*"
+      ],
       "js": [
         "vendor/browser-polyfill.js",
         "vendor/bower/jquery.min.js",

--- a/ext/scss/problem.scss
+++ b/ext/scss/problem.scss
@@ -1,0 +1,5 @@
+#content {
+  .buttton_bar {
+    margin-top: 1em;
+  }
+}

--- a/ext/scss/problem.scss
+++ b/ext/scss/problem.scss
@@ -1,5 +1,33 @@
-#content {
-  .buttton_bar {
-    margin-top: 1em;
+#container > .colmask > .colmid > .colleft > .col1 {
+  display: grid;
+  grid-template-columns: 1fr 300px;
+
+  #content {
+    grid-column: 1;
+
+    .buttton_bar {
+      margin-top: 1em;
+    }
+  }
+
+  #results-sidebar {
+    grid-column: 2;
+    margin-top: -1em;
+  }
+
+  @media screen and (max-width: 1200px) {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto;
+
+    #content {
+      grid-row: 1;
+    }
+
+    #results-sidebar {
+      border-top: 1px dotted #A1A39D;
+      grid-column: 1;
+      grid-row: 2;
+      margin: 0 1em 1em;
+    }
   }
 }


### PR DESCRIPTION
- Add links and show full names of problems in result and result list pages
![image](https://user-images.githubusercontent.com/29484605/212417391-b14842bb-17bd-4ef3-b752-1c3b29f2fc2f.png)
The problem names and links are cached when the user visits the problems page or lazy-loaded when needed

- Add `Submit another` and `All submissions` buttons to result page
![image](https://user-images.githubusercontent.com/29484605/212420908-ea52436b-5ad1-4734-9056-b8f525c27a1e.png)

- Add `Results` button on the problem page
![image](https://user-images.githubusercontent.com/29484605/212417041-62e70606-0f22-484a-9d25-976fc1e31acf.png)

- Add `Submit another` button to filtered result list page
![image](https://user-images.githubusercontent.com/29484605/212421076-db353889-8a4e-4db2-8d93-f26312704e6b.png)

- Add results sidebar to the problem page
![image](https://user-images.githubusercontent.com/29484605/212469034-e49f36bb-492d-455b-b8b0-e3ff351e4636.png)
![image](https://user-images.githubusercontent.com/29484605/212469073-cf08954f-49dc-4cca-a50e-b6b824477cb1.png)
![image](https://user-images.githubusercontent.com/29484605/212469112-1a78577d-f8e6-48f0-b2da-53eee278dce9.png)
