### PR TITLE
Add contest selector

### DIFF
--- a/ext/js/background.js
+++ b/ext/js/background.js
@@ -257,6 +257,22 @@
         return contestProblemList[contestID] ?? {};
     }
 
+    /**
+     * Save joined contest list in Storage
+     * @param {array} contestList contest list
+     */
+    function saveJoinedContestList(contestList) {
+        storage.set({ contestList });
+    }
+
+    /**
+     * Save joined contest list in Storage
+     * @return {array} contest list
+     */
+    async function getJoinedContestList() {
+        return (await storage.get('contestList')).contestList ?? [];
+    }
+
     retrieveLastContestID();
     setUpLastContestRedirect();
     setUpSessionCookies();
@@ -286,6 +302,10 @@
             saveContestProblemList(request.contestID, request.problems);
         } else if (request.action === 'getContestProblemList') {
             return getProblemList(request.contestID);
+        } else if (request.action === 'setJoinedContestList') {
+            saveJoinedContestList(request.contestList);
+        } else if (request.action === 'getJoinedContestList') {
+            return getJoinedContestList();
         }
         return new Promise(resolve => resolve(null));
     });

--- a/ext/js/contest-select.js
+++ b/ext/js/contest-select.js
@@ -1,0 +1,22 @@
+(function () {
+    'use strict';
+
+    function storeContestList() {
+        const table = $('#content h3:contains("Joined contests:")').next('table.results');
+        if (table.length === 0) return;
+        const rows = table.find('tr:not(:first-child)').map((index, el) => {
+            const link = $(el).find('td:nth-child(1) .stdlink');
+            return ({
+                href: link.attr('href'),
+                name: link.text(),
+                description: $(el).find('td:nth-child(2)').text(),
+            });
+        }).toArray();
+        browser.runtime.sendMessage({
+            action: 'setJoinedContestList',
+            contestList: rows,
+        });
+    }
+
+    storeContestList();
+})();

--- a/ext/js/contest.js
+++ b/ext/js/contest.js
@@ -1,5 +1,47 @@
 (function () {
     'use strict';
 
+    async function addContestChangeDialog() {
+        const contestList = await browser.runtime.sendMessage({
+            action: 'getJoinedContestList',
+        });
+        if (contestList.length === 0) return;
+
+        const link = $('#header a[href="/contest/select"]');
+        const table = $('<table class="results" />');
+
+        contestList.forEach(({ name, href }) => {
+            const row = $('<tr><td><a class="stdlink" /></td></tr>');
+            row.find('a')
+                .text(name)
+                .attr('href', href);
+            table.append(row);
+        });
+
+        const lastRow = $('<tr><td class="centered"><a class="stdlink">See all contests</a></td></tr>');
+        lastRow.find('a').attr('href', '/contest/select');
+        table.append(lastRow);
+
+        const dialog = $(
+            '<dialog id="contest-select-dialog">' +
+            '   <h3>Select contest</h3>' +
+            '</dialog>'
+        )
+            .append(table)
+            .insertAfter(link);
+
+        $(document).on('pointerdown', function (e) {
+            if ($(e.target).closest(dialog).length === 0) dialog[0].close();
+        });
+
+        link.on('click', (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            dialog[0].show();
+        });
+    }
+
     browser.runtime.sendMessage({action: 'saveLastContestID'});
+
+    addContestChangeDialog().catch(console.error);
 })();

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -68,6 +68,15 @@
       "css": ["css/general.css"]
     },
     {
+      "matches": ["*://satori.tcs.uj.edu.pl/contest/select"],
+      "js": [
+        "vendor/browser-polyfill.js",
+        "vendor/bower/jquery.min.js",
+        "js/contest-select.js"
+      ],
+      "run_at": "document_end"
+    },
+    {
       "matches": ["*://satori.tcs.uj.edu.pl/contest/*/*"],
       "exclude_matches": ["*://satori.tcs.uj.edu.pl/contest/apply/*"],
       "js": [

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -81,9 +81,11 @@
       "exclude_matches": ["*://satori.tcs.uj.edu.pl/contest/apply/*"],
       "js": [
         "vendor/browser-polyfill.js",
+        "vendor/bower/jquery.min.js",
         "js/contest.js"
       ],
-      "run_at": "document_start"
+      "run_at": "document_end",
+      "css": ["css/contest.css"]
     },
     {
       "matches": ["*://satori.tcs.uj.edu.pl/*/ranking/*"],

--- a/ext/scss/contest.scss
+++ b/ext/scss/contest.scss
@@ -1,0 +1,26 @@
+#contest-select-dialog {
+  z-index: 100;
+  top: 32px;
+  left: auto;
+  right: 2em;
+  border: 1px dotted #A1A39D;
+  box-shadow: 0 2px 3px 0 #0001;
+  width: 200px;
+  padding: 0;
+
+  tr {
+    text-align: left;
+  }
+
+  td {
+    padding: 1px 2px;
+  }
+
+  .stdlink {
+    color: #1B1972 !important;
+  }
+
+  h3 {
+    margin: 8px 0;
+  }
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -104,9 +104,9 @@ gulp.task('compress', gulp.series('dist', () => gulp
     .pipe(gulp.dest('bin'))
 ));
 
-gulp.task('watch', gulp.series('build', () => {
-    gulp.watch(path.join(EXT_DIR, 'scss/**/*.scss'), ['sass']);
-    gulp.watch(path.join(EXT_DIR, 'js/**/*.js'), ['jshint']);
-}));
+gulp.task('watch', gulp.series('build', gulp.parallel(
+    () => gulp.watch(path.join(EXT_DIR, 'scss/**/*.scss'), gulp.series('sass')),
+    () => gulp.watch(path.join(EXT_DIR, 'js/**/*.js'), gulp.series('jshint')),
+)));
 
 gulp.task('default', gulp.series('dist'));


### PR DESCRIPTION
![image](https://github.com/m4tx/satori-enhancements/assets/29484605/8bf55c6d-5566-4989-9e8d-2d023d381c4f)

The change adds a picker to the contest change button.
The extension caches joined contests every time the `/contest/select` page is visited