### PR TITLE
Migrate to Manifest V3

### DIFF
--- a/ext/js/background.js
+++ b/ext/js/background.js
@@ -115,7 +115,7 @@
     }
 
     /**
-     * Setups a declarative net request rules to redirect to the last contest
+     * Sets up a declarative net request rules to redirect to the last contest
      * if the user just entered Satori webpage.
      */
     function updateLastContestRedirectRules() {

--- a/ext/js/general.js
+++ b/ext/js/general.js
@@ -3,9 +3,9 @@
 
     browser.runtime.sendMessage({ action: 'enablePageAction' });
 
-    const BANNER_URL = browser.extension.getURL('images/satori_banner.png');
-    const TCS_LOGO_URL = browser.extension.getURL('images/tcslogo.svg');
-    const ALT_TCS_LOGO_URL = browser.extension.getURL('images/alttcslogo.png');
+    const BANNER_URL = browser.runtime.getURL('images/satori_banner.png');
+    const TCS_LOGO_URL = browser.runtime.getURL('images/tcslogo.svg');
+    const ALT_TCS_LOGO_URL = browser.runtime.getURL('images/alttcslogo.png');
 
     let storage = browser.storage.sync || browser.storage.local;
 

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -1,5 +1,5 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
 
     "name": "Satori Enhancements",
     "description": "Adds a few useful enhancements to Satori Online Judge website.",
@@ -21,17 +21,17 @@
     },
 
     "options_ui": {
-        "page": "options.html",
-        "chrome_style": true,
-        "browser_style": true
+        "page": "options.html"
     },
 
     "permissions": [
         "storage",
         "notifications",
-        "webRequest",
-        "webRequestBlocking",
-        "cookies",
+        "declarativeNetRequestWithHostAccess",
+        "cookies"
+    ],
+
+    "host_permissions": [
         "*://satori.tcs.uj.edu.pl/*"
     ],
 
@@ -50,7 +50,12 @@
         ]
     },
 
-    "web_accessible_resources": ["images/*.png", "images/*.svg"],
+    "web_accessible_resources": [
+        {
+            "resources": ["images/*.png", "images/*.svg"],
+            "matches": ["*://satori.tcs.uj.edu.pl/*"]
+        }
+    ],
 
     "content_scripts": [
         {


### PR DESCRIPTION
- Updated `manifest.json` to V3
- Fixed use of moved `browser.extension.getURL` function
- Replaced `webRequest` usage with `declarativeNetRequest`

These changes are enough to support Firefox, for Chrome support the background script must be converted to a service worker